### PR TITLE
Add a check to make sure provided secret is a string.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -111,6 +111,10 @@ function noQsMethod(options) {
 
 function authorize(options, onConnection) {
   options = xtend({ decodedPropertyName: 'decoded_token', encodedPropertyName: 'encoded_token' }, options);
+  
+  if (typeof options.secret !== 'string') {
+    throw new Error(`Provided secret "${options.secret}" is invalid, must be of type string.`)
+  }
 
   if (!options.handshake) {
     return noQsMethod(options);


### PR DESCRIPTION
If undefined is (accidentally) used as secret while providing the options a very weird situation will occur where the server seems to not do anything. No errors, no timeouts, nothing. And all events send by the client will be ignored making this problem very hard to debug.

```
const JWTOptions: JwtAuthOptions = {
    secret: process.env.JWT_SECRET as string,
    timeout: 5_000,
    decodedPropertyName: 'decodedToken',
};
```

The situation where this occured was with the options snippet provided above. My environment file wasn't actually loaded yet thus resulting in the secret being undefined and causing this weird and hard to debug problem.

This PR adds a check to prevent the secret being passed as anything other than a string.
