### PR TITLE
Fixed regressions of b0cd246 and 3128fdf

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -113,7 +113,7 @@ function authorize(options, onConnection) {
   options = xtend({ decodedPropertyName: 'decoded_token', encodedPropertyName: 'encoded_token' }, options);
 
   if (typeof options.secret !== 'string' && typeof options.secret !== 'function') {
-    throw new Error('Provided secret "' + options.secret + '" is invalid, must be of type string or function.')
+    throw new Error('Provided secret "' + options.secret + '" is invalid, must be of type string or function.');
   }
 
   if (!options.handshake) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -111,9 +111,9 @@ function noQsMethod(options) {
 
 function authorize(options, onConnection) {
   options = xtend({ decodedPropertyName: 'decoded_token', encodedPropertyName: 'encoded_token' }, options);
-  
-  if (typeof options.secret !== 'string') {
-    throw new Error(`Provided secret "${options.secret}" is invalid, must be of type string.`)
+
+  if (typeof options.secret !== 'string' && typeof options.secret !== 'function') {
+    throw new Error('Provided secret "' + options.secret + '" is invalid, must be of type string or function.')
   }
 
   if (!options.handshake) {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
   },
   "license": "MIT",
   "dependencies": {
+    "jsonwebtoken": "^8.3.0",
+    "xtend": "~2.1.2"
   },
   "devDependencies": {
     "@types/socket.io": "~1.4.29",
@@ -31,8 +33,6 @@
     "mocha": "~3.2.0",
     "request": "~2.81.0",
     "serve-static": "^1.12.1",
-    "jsonwebtoken": "^8.3.0",
-    "xtend": "~2.1.2",
     "server-destroy": "~1.0.1",
     "should": "~11.2.1",
     "socket.io": "^1.7.3",


### PR DESCRIPTION
3128fdf:
- Secret can be a string or function
- Compatibility with older node versions
- `npm test` does work now

b0cd246:
- Fixed dependencies