### PR TITLE
Pass token header to secret fetching function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -243,13 +243,18 @@ function getSecret (request, secret, token, callback) {
       return callback({ code: 'invalid_token', message: 'jwt signature is required' });
     }
 
-    let decodedToken = jwt.decode(token);
+    let decodedToken = jwt.decode(token, { complete: true });
 
     if (!decodedToken) {
       return callback({ code: 'invalid_token', message: 'jwt malformed' });
     }
 
-    secret(request, decodedToken, callback);
+    const arity = secret.length;
+    if (arity == 4) {
+      secret(request, decodedToken.header, decodedToken.payload, callback);
+    } else { // arity == 3
+      secret(request, decodedToken.payload, callback);
+    }
   } else {
     callback(null, secret);
   }


### PR DESCRIPTION
# Pull Request Report

### Description

In some cases secret function might need to get information about token header, not only payload. Example of such info is `kid` field (to do not hardcode it).
To achieve that and also maintain backward compatibility, arity of secret function is checked.

Similiar mechanism exists in express-jwt: https://github.com/auth0/express-jwt/blob/5766a24aeb7db15b8a183c59b4a9145552702f0e/lib/index.js#L91-L98
### Type of change

- [ ] Bug fix (fix to an issue)
- [x] New feature (changes to functionality)
- [ ] Big change (fix or feature that would cause existing functionality to work as expected)

### Testing

Please describe the tests that you ran to verify your changes. Provide any instructions that will allow us to reproduce it. Please also list any relevant details for your test configuration.

**Test Configuration**

* Framework version:
* Language version:
* Browser version:

### Additional info

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings and errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
