### PR TITLE
Fix typings for secret callback with 4 arguments

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -31,7 +31,7 @@ declare module 'socketio-jwt' {
     customDecoded?: (decoded: object) => object;
 
     callback?: (false | number);
-    secret: (string | ((request: any, decodedToken: object, callback: ISocketCallback) => void));
+    secret: (string | ((request: any, decodedToken: object, callback: ISocketCallback) => void) | ((request: any, header: object, payload: object, callback: ISocketCallback) => void));
 
     encodedPropertyName?: string;
     decodedPropertyName?: string;


### PR DESCRIPTION
# Pull Request Report

### Description

Add typings for the 4 arguments secret callback which is used here: https://github.com/auth0-community/auth0-socketio-jwt/blob/master/lib/index.js#L253

### Type of change

- [x] Bug fix (fix to an issue)

### Testing

None

**Test Configuration**

* Framework version:
* Language version:
* Browser version:

### Additional info

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings and errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
