### PR TITLE
Fix Authorize Secret Doesn't Accept buffer

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -119,8 +119,8 @@ function noQsMethod (options) {
 function authorize (options) {
   options = xtend({ decodedPropertyName: 'decoded_token', encodedPropertyName: 'encoded_token' }, options);
 
-  if (typeof options.secret !== 'string' && typeof options.secret !== 'function') {
-    throw new Error(`Provided secret ${options.secret} is invalid, must be of type string or function.`);
+  if (typeof options.secret !== 'string' && typeof options.secret !== 'function' && !Buffer.isBuffer(options.secret)) {
+    throw new Error(`Provided secret ${options.secret} is invalid, must be of type string or function or buffer.`);
   }
 
   if (!options.handshake) {


### PR DESCRIPTION


# Pull Request Report

### Description

JWT library is accepting buffer however the input check doesn't allow that. (only function or string)


```
io.use(
  socketioJwt.authorize({
    secret: Buffer.from(SECRET, "base64");
  })
);
```

### Type of change

-[x] Bug fix (fix to an issue)


**Test Configuration**

* Framework version: 4.6.2
* Language version: 12.18.3
* Browser version:  N/A (Node)

### Additional info

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [] My changes generate no new warnings and errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
